### PR TITLE
Add CONFIG_CLOCK_DFLL_RUNSTDY for SAMD21

### DIFF
--- a/peripheral/clk_sam_d21/config/clk.py
+++ b/peripheral/clk_sam_d21/config/clk.py
@@ -450,6 +450,11 @@ dfllOndemand.addKey("Disable",str(0),"Always Enable")
 dfllOndemand.addKey("Enable",str(1),"Only on Peripheral Request")
 dfllOndemand.setDefaultValue(0)
 
+dfllRunstdy = coreComponent.createBooleanSymbol("CONFIG_CLOCK_DFLL_RUNSTDY", dfll_Menu)
+dfllRunstdy.setLabel("Run DFLL in Standby Sleep Mode")
+dfllRunstdy.setDescription("DFLL to run in standby mode or not")
+dfllRunstdy.setDefaultValue(False)
+
 dfllUsb = coreComponent.createBooleanSymbol("CONFIG_CLOCK_DFLL_USB", dfll_Menu)
 dfllUsb.setLabel("USB Clock Recovery Mode")
 dfllUsb.setDescription("Enable or Disable USB Clock Recovery Mode")


### PR DESCRIPTION
CONFIG_CLOCK_DFLL_RUNSTDY must exist & have a value or Harmony3 code generation will fail with:
===> CONFIG_CLOCK_DFLL_RUNSTDY [in template "plib_clock.c.ftl at line 195, column 43] has evaluated to null or missing.

These missing lines were copied from the existing SAML21 clk.py