### PR TITLE
fix(can_03247): premature TX-FIFO-empty interrupt causes interrupt storm / hang on second transmit

### DIFF
--- a/peripheral/can_03247/templates/plib_canfd.c.ftl
+++ b/peripheral/can_03247/templates/plib_canfd.c.ftl
@@ -477,24 +477,30 @@ bool ${CAN_INSTANCE_NAME}_MessageTransmit(uint32_t id, uint8_t length, uint8_t* 
         if (fifoQueueNum == 0U)
         {
 <#if TX_QUEUE_USE == true>
-<#if CAN_INTERRUPT_MODE == true>
-            CFD${CAN_INSTANCE_NUM}TXQCON |= _CFD${CAN_INSTANCE_NUM}TXQCON_TXQEIE_MASK;
-
-</#if>
             /* Request the transmit */
             CFD${CAN_INSTANCE_NUM}TXQCON |= _CFD${CAN_INSTANCE_NUM}TXQCON_UINC_MASK;
             CFD${CAN_INSTANCE_NUM}TXQCON |= _CFD${CAN_INSTANCE_NUM}TXQCON_TXREQ_MASK;
+<#if CAN_INTERRUPT_MODE == true>
+
+            /* Enable the Tx Queue empty (completion) interrupt only after the
+             * message is queued. Enabling it while the queue is still empty
+             * raises TXQEIF immediately and fires a premature interrupt. */
+            CFD${CAN_INSTANCE_NUM}TXQCON |= _CFD${CAN_INSTANCE_NUM}TXQCON_TXQEIE_MASK;
+</#if>
 </#if>
         }
         else
         {
-<#if CAN_INTERRUPT_MODE == true>
-            *(volatile uint32_t *)(&CFD${CAN_INSTANCE_NUM}FIFOCON1 + ((fifoQueueNum - 1U) * CANFD_FIFO_OFFSET)) |= _CFD${CAN_INSTANCE_NUM}FIFOCON1_TFERFFIE_MASK;
-
-</#if>
             /* Request the transmit */
             *(volatile uint32_t *)(&CFD${CAN_INSTANCE_NUM}FIFOCON1 + ((fifoQueueNum - 1U) * CANFD_FIFO_OFFSET)) |= _CFD${CAN_INSTANCE_NUM}FIFOCON1_UINC_MASK;
             *(volatile uint32_t *)(&CFD${CAN_INSTANCE_NUM}FIFOCON1 + ((fifoQueueNum - 1U) * CANFD_FIFO_OFFSET)) |= _CFD${CAN_INSTANCE_NUM}FIFOCON1_TXREQ_MASK;
+<#if CAN_INTERRUPT_MODE == true>
+
+            /* Enable the Tx FIFO empty (completion) interrupt only after the
+             * message is queued. Enabling it while the FIFO is still empty
+             * raises TFERFFIF immediately and fires a premature interrupt. */
+            *(volatile uint32_t *)(&CFD${CAN_INSTANCE_NUM}FIFOCON1 + ((fifoQueueNum - 1U) * CANFD_FIFO_OFFSET)) |= _CFD${CAN_INSTANCE_NUM}FIFOCON1_TFERFFIE_MASK;
+</#if>
         }
 <#if CAN_INTERRUPT_MODE == true>
         CFD${CAN_INSTANCE_NUM}INT |= _CFD${CAN_INSTANCE_NUM}INT_TXIE_MASK;
@@ -1488,6 +1494,12 @@ void __attribute__((used)) ${CAN_INSTANCE_NAME}_MISC_InterruptHandler(void)
 */
 void __attribute__((used)) ${CAN_INSTANCE_NAME}_InterruptHandler(void)
 {
+    /* The IFS flag is latched: if the CFD${CAN_INSTANCE_NUM}INT condition that set it
+     * cleared before this ISR was entered, none of the handlers below runs and the
+     * flag is never cleared, re-entering this ISR forever. Clear it up front; any
+     * condition still active in CFD${CAN_INSTANCE_NUM}INT will latch it again. */
+    ${CAN_IFS_REG}CLR = _${CAN_IFS_REG}_CAN${CAN_INSTANCE_NUM}IF_MASK;
+
     /* Call CAN MISC interrupt handler if SERRIF/CERRIF/IVMIF interrupt flag is set */
     if ((CFD${CAN_INSTANCE_NUM}INT & (_CFD${CAN_INSTANCE_NUM}INT_SERRIF_MASK | _CFD${CAN_INSTANCE_NUM}INT_CERRIF_MASK | _CFD${CAN_INSTANCE_NUM}INT_IVMIF_MASK)) != 0U)
     {


### PR DESCRIPTION
# Description
In plib_canfd.c.ftl, xxx_MessageTransmit() enables TFERFFIE (TXQEIE for the TX Queue) before queueing the message with UINC. TFERFFIF is a level flag that is already set when the TX FIFO is empty. On every transmit after the first (when CFDxINT.TXIE is already set and the FIFO has drained), the enable instantly asserts the interrupt and latches the IFSy.CANxIF flag.
If the CPU executes UINC within the interrupt latency window, the FIFO becomes non-empty and CFDxINT.TXIF deasserts before the ISR vectors. xxx_InterruptHandler() then finds no active CFDxINT flag, dispatches nothing, and returns without clearing IFSy.CANxIF — the ISR re-enters indefinitely and the application hangs.

## Reproduction
Stock can_fd_operation_interrupt_timestamp demo (csp_apps_pic32mk), PIC32MK MCM Curiosity Pro, csp v3.23.0. Select menu option 1 or 2 twice: the first frame transmits, the second hangs the firmware in the interrupt storm described above. Inserting any delay (e.g. a printf) between the TFERFFIE enable and UINC masks the bug, confirming the race.

## Fix

Enable the completion interrupt (TFERFFIE/TXQEIE) only after UINC/TXREQ. Since these are level flags, no completion event can be lost.
Defensively clear the latched IFS flag at ISR entry so a transient condition can never cause an unclearable re-entry; any still-active CFDxINT condition re-latches it.

## Testing

Regenerated the demo with the patched template and verified on PIC32MK MCM Curiosity Pro hardware: repeated FD and classic transmissions all complete, callback fires after actual frame transmission, no hang.